### PR TITLE
modified method _removeWindowResize of detach('resize', fn)

### DIFF
--- a/1.0/index.js
+++ b/1.0/index.js
@@ -106,7 +106,7 @@ KISSY.add(function (S) {
 		},
 		_removeWindowResize:function(){
 			var that = this;
-            S.one(window).detach('touchmove', that._doWindowResize);
+            S.one(window).detach('resize', that._doWindowResize);
 		},
 		_doWindowResize:function(e){
 			var that = this;


### PR DESCRIPTION
调试的时候，发现去掉遮罩后，缩放窗口的时候，总是报错，故修改源码。